### PR TITLE
tests: update libraries

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "docs", "formatter", "linting", "test", "typesafety"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:411050a706445d379d242eae3ef789cb2d5f7c1da8fb18ec9e7eb262794d81ff"
+content_hash = "sha256:d99c01bc2fd0d63feb6bc0801a2498e1c96202731bc102135e050c4c88be9896"
 
 [[metadata.targets]]
 requires_python = ">=3.11"
@@ -817,23 +817,23 @@ files = [
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
-requires_python = ">=3.9"
+version = "9.0.2"
+requires_python = ">=3.10"
 summary = "pytest: simple powerful testing with Python"
 groups = ["test"]
 marker = "python_version >= \"3.11\""
 dependencies = [
     "colorama>=0.4; sys_platform == \"win32\"",
     "exceptiongroup>=1; python_version < \"3.11\"",
-    "iniconfig>=1",
-    "packaging>=20",
+    "iniconfig>=1.0.1",
+    "packaging>=22",
     "pluggy<2,>=1.5",
     "pygments>=2.7.2",
     "tomli>=1; python_version < \"3.11\"",
 ]
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b"},
+    {file = "pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11"},
 ]
 
 [[package]]
@@ -890,7 +890,7 @@ name = "python-dateutil"
 version = "2.9.0.post0"
 requires_python = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
 summary = "Extensions to the standard Python datetime module"
-groups = ["docs", "test"]
+groups = ["docs"]
 marker = "python_version >= \"3.11\""
 dependencies = [
     "six>=1.5",
@@ -990,91 +990,11 @@ name = "six"
 version = "1.17.0"
 requires_python = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
 summary = "Python 2 and 3 compatibility utilities"
-groups = ["docs", "test"]
+groups = ["docs"]
 marker = "python_version >= \"3.11\""
 files = [
     {file = "six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274"},
     {file = "six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81"},
-]
-
-[[package]]
-name = "time-machine"
-version = "2.19.0"
-requires_python = ">=3.9"
-summary = "Travel through time in your tests."
-groups = ["test"]
-marker = "python_version >= \"3.11\""
-dependencies = [
-    "python-dateutil",
-]
-files = [
-    {file = "time_machine-2.19.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:5ee91664880434d98e41585c3446dac7180ec408c786347451ddfca110d19296"},
-    {file = "time_machine-2.19.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:ed3732b83a893d1c7b8cabde762968b4dc5680ee0d305b3ecca9bb516f4e3862"},
-    {file = "time_machine-2.19.0-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:6ba0303e9cc9f7f947e344f501e26bedfb68fab521e3c2729d370f4f332d2d55"},
-    {file = "time_machine-2.19.0-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2851825b524a988ee459c37c1c26bdfaa7eff78194efb2b562ea497a6f375b0a"},
-    {file = "time_machine-2.19.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:68d32b09ecfd7fef59255c091e8e7c24dd117f882c4880b5c7ab8c5c32a98f89"},
-    {file = "time_machine-2.19.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:60c46ab527bf2fa144b530f639cc9e12803524c9e1f111dc8c8f493bb6586eeb"},
-    {file = "time_machine-2.19.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:56f26ab9f0201c453d18fe76bb7d1cf05fe58c1b9d9cb0c7d243d05132e01292"},
-    {file = "time_machine-2.19.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:6c806cf3c1185baa1d807b7f51bed0db7a6506832c961d5d1b4c94c775749bc0"},
-    {file = "time_machine-2.19.0-cp311-cp311-win32.whl", hash = "sha256:b30039dfd89855c12138095bee39c540b4633cbc3684580d684ef67a99a91587"},
-    {file = "time_machine-2.19.0-cp311-cp311-win_amd64.whl", hash = "sha256:13ed8b34430f1de79905877f5600adffa626793ab4546a70a99fb72c6a3350d8"},
-    {file = "time_machine-2.19.0-cp311-cp311-win_arm64.whl", hash = "sha256:cc29a50a0257d8750b08056b66d7225daab47606832dea1a69e8b017323bf511"},
-    {file = "time_machine-2.19.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:c85cf437dc3c07429456d8d6670ac90ecbd8241dcd0fbf03e8db2800576f91ff"},
-    {file = "time_machine-2.19.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d9238897e8ef54acdf59f5dff16f59ca0720e7c02d820c56b4397c11db5d3eb9"},
-    {file = "time_machine-2.19.0-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:e312c7d5d6bfffb96c6a7b39ff29e3046de100d7efaa3c01552654cfbd08f14c"},
-    {file = "time_machine-2.19.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:714c40b2c90d1c57cc403382d5a9cf16e504cb525bfe9650095317da3c3d62b5"},
-    {file = "time_machine-2.19.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2eaa1c675d500dc3ccae19e9fb1feff84458a68c132bbea47a80cc3dd2df7072"},
-    {file = "time_machine-2.19.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e77a414e9597988af53b2b2e67242c9d2f409769df0d264b6d06fda8ca3360d4"},
-    {file = "time_machine-2.19.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:cd93996970e11c382b04d4937c3cd0b0167adeef14725ece35aae88d8a01733c"},
-    {file = "time_machine-2.19.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:8e20a6d8d6e23174bd7e931e134d9610b136db460b249d07e84ecdad029ec352"},
-    {file = "time_machine-2.19.0-cp312-cp312-win32.whl", hash = "sha256:95afc9bc65228b27be80c2756799c20b8eb97c4ef382a9b762b6d7888bc84099"},
-    {file = "time_machine-2.19.0-cp312-cp312-win_amd64.whl", hash = "sha256:e84909af950e2448f4e2562ea5759c946248c99ab380d2b47d79b62bd76fa236"},
-    {file = "time_machine-2.19.0-cp312-cp312-win_arm64.whl", hash = "sha256:0390a1ea9fa7e9d772a39b7c61b34fdcca80eb9ffac339cc0441c6c714c81470"},
-    {file = "time_machine-2.19.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:5e172866753e6041d3b29f3037dc47c20525176a494a71bbd0998dfdc4f11f2f"},
-    {file = "time_machine-2.19.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:f70f68379bd6f542ae6775cce9a4fa3dcc20bf7959c42eaef871c14469e18097"},
-    {file = "time_machine-2.19.0-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:e69e0b0f694728a00e72891ef8dd00c7542952cb1c87237db594b6b27d504a96"},
-    {file = "time_machine-2.19.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:3ae0a8b869574301ec5637e32c270c7384cca5cd6e230f07af9d29271a7fa293"},
-    {file = "time_machine-2.19.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:554e4317de90e2f7605ff80d153c8bb56b38c0d0c0279feb17e799521e987b8c"},
-    {file = "time_machine-2.19.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:6567a5ec5538ed550539ac29be11b3cb36af1f9894e2a72940cba0292cc7c3c9"},
-    {file = "time_machine-2.19.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:82e9ffe8dfff07b0d810a2ad015a82cd78c6a237f6c7cf185fa7f747a3256f8a"},
-    {file = "time_machine-2.19.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:7e1c4e578cdd69b3531d8dd3fbcb92a0cd879dadb912ee37af99c3a9e3c0d285"},
-    {file = "time_machine-2.19.0-cp313-cp313-win32.whl", hash = "sha256:72dbd4cbc3d96dec9dd281ddfbb513982102776b63e4e039f83afb244802a9e5"},
-    {file = "time_machine-2.19.0-cp313-cp313-win_amd64.whl", hash = "sha256:e17e3e089ac95f9a145ce07ff615e3c85674f7de36f2d92aaf588493a23ffb4b"},
-    {file = "time_machine-2.19.0-cp313-cp313-win_arm64.whl", hash = "sha256:149072aff8e3690e14f4916103d898ea0d5d9c95531b6aa0995251c299533f7b"},
-    {file = "time_machine-2.19.0-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:f3589fee1ed0ab6ee424a55b0ea1ec694c4ba64cc26895bcd7d99f3d1bc6a28a"},
-    {file = "time_machine-2.19.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:7887e85275c4975fe54df03dcdd5f38bd36be973adc68a8c77e17441c3b443d6"},
-    {file = "time_machine-2.19.0-cp313-cp313t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:ce0be294c209928563fcce1c587963e60ec803436cf1e181acd5bc1e425d554b"},
-    {file = "time_machine-2.19.0-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:a62fd1ab380012c86f4c042010418ed45eb31604f4bf4453e17c9fa60bc56a29"},
-    {file = "time_machine-2.19.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b25ec853a4530a5800731257f93206b12cbdee85ede964ebf8011b66086a7914"},
-    {file = "time_machine-2.19.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:a430e4d0e0556f021a9c78e9b9f68e5e8910bdace4aa34ed4d1a73e239ed9384"},
-    {file = "time_machine-2.19.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:2415b7495ec4364c8067071e964fbadfe746dd4cdb43983f2f0bd6ebed13315c"},
-    {file = "time_machine-2.19.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:dbfc6b90c10f288594e1bf89a728a98cc0030791fd73541bbdc6b090aff83143"},
-    {file = "time_machine-2.19.0-cp313-cp313t-win32.whl", hash = "sha256:16f5d81f650c0a4d117ab08036dc30b5f8b262e11a4a0becc458e7f1c011b228"},
-    {file = "time_machine-2.19.0-cp313-cp313t-win_amd64.whl", hash = "sha256:645699616ec14e147094f601e6ab9553ff6cea37fad9c42720a6d7ed04bcd5dc"},
-    {file = "time_machine-2.19.0-cp313-cp313t-win_arm64.whl", hash = "sha256:b32daa965d13237536ea3afaa5ad61ade2b2d9314bc3a20196a0d2e1d7b57c6a"},
-    {file = "time_machine-2.19.0-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:31cb43c8fd2d961f31bed0ff4e0026964d2b35e5de9e0fabbfecf756906d3612"},
-    {file = "time_machine-2.19.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:bdf481a75afc6bff3e520db594501975b652f7def21cd1de6aa971d35ba644e6"},
-    {file = "time_machine-2.19.0-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:00bee4bb950ac6a08d62af78e4da0cf2b4fc2abf0de2320d0431bf610db06e7c"},
-    {file = "time_machine-2.19.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9f02199490906582302ce09edd32394fb393271674c75d7aa76c7a3245f16003"},
-    {file = "time_machine-2.19.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e35726c7ba625f844c13b1fc0d4f81f394eefaee1d3a094a9093251521f2ef15"},
-    {file = "time_machine-2.19.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:304315023999cd401ff02698870932b893369e1cfeb2248d09f6490507a92e97"},
-    {file = "time_machine-2.19.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:9765d4f003f263ea8bfd90d2d15447ca4b3dfa181922cf6cf808923b02ac180a"},
-    {file = "time_machine-2.19.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7837ef3fd5911eb9b480909bb93d922737b6bdecea99dfcedb0a03807de9b2d3"},
-    {file = "time_machine-2.19.0-cp314-cp314-win32.whl", hash = "sha256:4bb5bd43b1bdfac3007b920b51d8e761f024ed465cfeec63ac4296922a4ec428"},
-    {file = "time_machine-2.19.0-cp314-cp314-win_amd64.whl", hash = "sha256:f583bbd0aa8ab4a7c45a684bf636d9e042d466e30bcbae1d13e7541e2cbe7207"},
-    {file = "time_machine-2.19.0-cp314-cp314-win_arm64.whl", hash = "sha256:f379c6f8a6575a8284592179cf528ce89373f060301323edcc44f1fa1d37be12"},
-    {file = "time_machine-2.19.0-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:a3b8981f9c663b0906b05ab4d0ca211fae4b63b47c6ec26de5374fe56c836162"},
-    {file = "time_machine-2.19.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:8e9c6363893e7f52c226afbebb23e825259222d100e67dfd24c8a6d35f1a1907"},
-    {file = "time_machine-2.19.0-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:206fcd6c9a6f00cac83db446ad1effc530a8cec244d2780af62db3a2d0a9871b"},
-    {file = "time_machine-2.19.0-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:bf33016a1403c123373ffaeff25e26e69d63bf2c63b6163932efed94160db7ef"},
-    {file = "time_machine-2.19.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9247c4bb9bbd3ff584ef4efbdec8efd9f37aa08bcfc4728bde1e489c2cb445bd"},
-    {file = "time_machine-2.19.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:77f9bb0b86758d1f2d9352642c874946ad5815df53ef4ca22eb9d532179fe50d"},
-    {file = "time_machine-2.19.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:0b529e262df3b9c449f427385f4d98250828c879168c2e00eec844439f40b370"},
-    {file = "time_machine-2.19.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9199246e31cdc810e5d89cb71d09144c4d745960fdb0824da4994d152aca3303"},
-    {file = "time_machine-2.19.0-cp314-cp314t-win32.whl", hash = "sha256:0fe81bae55b7aefc2c2a34eb552aa82e6c61a86b3353a3c70df79b9698cb02ca"},
-    {file = "time_machine-2.19.0-cp314-cp314t-win_amd64.whl", hash = "sha256:7253791b8d7e7399fbeed7a8193cb01bc004242864306288797056badbdaf80b"},
-    {file = "time_machine-2.19.0-cp314-cp314t-win_arm64.whl", hash = "sha256:536bd1ac31ab06a1522e7bf287602188f502dc19d122b1502c4f60b1e8efac79"},
-    {file = "time_machine-2.19.0.tar.gz", hash = "sha256:7c5065a8b3f2bbb449422c66ef71d114d3f909c276a6469642ecfffb6a0fcd29"},
 ]
 
 [[package]]

--- a/py3.10.lock
+++ b/py3.10.lock
@@ -5,7 +5,7 @@
 groups = ["default", "docs", "formatter", "linting", "test", "typesafety"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:411050a706445d379d242eae3ef789cb2d5f7c1da8fb18ec9e7eb262794d81ff"
+content_hash = "sha256:d99c01bc2fd0d63feb6bc0801a2498e1c96202731bc102135e050c4c88be9896"
 
 [[metadata.targets]]
 requires_python = "==3.10.*"
@@ -579,23 +579,23 @@ files = [
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
-requires_python = ">=3.9"
+version = "9.0.2"
+requires_python = ">=3.10"
 summary = "pytest: simple powerful testing with Python"
 groups = ["test"]
 marker = "python_version == \"3.10\""
 dependencies = [
     "colorama>=0.4; sys_platform == \"win32\"",
     "exceptiongroup>=1; python_version < \"3.11\"",
-    "iniconfig>=1",
-    "packaging>=20",
+    "iniconfig>=1.0.1",
+    "packaging>=22",
     "pluggy<2,>=1.5",
     "pygments>=2.7.2",
     "tomli>=1; python_version < \"3.11\"",
 ]
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b"},
+    {file = "pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11"},
 ]
 
 [[package]]
@@ -652,7 +652,7 @@ name = "python-dateutil"
 version = "2.9.0.post0"
 requires_python = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
 summary = "Extensions to the standard Python datetime module"
-groups = ["docs", "test"]
+groups = ["docs"]
 marker = "python_version == \"3.10\""
 dependencies = [
     "six>=1.5",
@@ -714,36 +714,11 @@ name = "six"
 version = "1.17.0"
 requires_python = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
 summary = "Python 2 and 3 compatibility utilities"
-groups = ["docs", "test"]
+groups = ["docs"]
 marker = "python_version == \"3.10\""
 files = [
     {file = "six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274"},
     {file = "six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81"},
-]
-
-[[package]]
-name = "time-machine"
-version = "2.19.0"
-requires_python = ">=3.9"
-summary = "Travel through time in your tests."
-groups = ["test"]
-marker = "python_version == \"3.10\""
-dependencies = [
-    "python-dateutil",
-]
-files = [
-    {file = "time_machine-2.19.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:b5169018ef47206997b46086ce01881cd3a4666fd2998c9d76a87858ca3e49e9"},
-    {file = "time_machine-2.19.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:85bb7ed440fccf6f6d0c8f7d68d849e7c3d1f771d5e0b2cdf871fa6561da569f"},
-    {file = "time_machine-2.19.0-cp310-cp310-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:a3b12028af1cdc09ccd595be2168b7b26f206c1e190090b048598fbe278beb8e"},
-    {file = "time_machine-2.19.0-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:c261f073086cf081d1443cbf7684148c662659d3d139d06b772bfe3fe7cc71a6"},
-    {file = "time_machine-2.19.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:011954d951230a9f1079f22b39ed1a3a9abb50ee297dfb8c557c46351659d94d"},
-    {file = "time_machine-2.19.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:b0f83308b29c7872006803f2e77318874eb84d0654f2afe0e48e3822e7a2e39b"},
-    {file = "time_machine-2.19.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:39733ef844e2984620ec9382a42d00cccc4757d75a5dd572be8c2572e86e50b9"},
-    {file = "time_machine-2.19.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:f8db99f6334432e9ffbf00c215caf2ae9773f17cec08304d77e9e90febc3507b"},
-    {file = "time_machine-2.19.0-cp310-cp310-win32.whl", hash = "sha256:72bf66cd19e27ffd26516b9cbe676d50c2e0b026153289765dfe0cf406708128"},
-    {file = "time_machine-2.19.0-cp310-cp310-win_amd64.whl", hash = "sha256:46f1c945934ce3d6b4f388b8e581fce7f87ec891ea90d7128e19520e434f96f0"},
-    {file = "time_machine-2.19.0-cp310-cp310-win_arm64.whl", hash = "sha256:fb4897c7a5120a4fd03f0670f332d83b7e55645886cd8864a71944c4c2e5b35b"},
-    {file = "time_machine-2.19.0.tar.gz", hash = "sha256:7c5065a8b3f2bbb449422c66ef71d114d3f909c276a6469642ecfffb6a0fcd29"},
 ]
 
 [[package]]

--- a/py3.11.lock
+++ b/py3.11.lock
@@ -5,7 +5,7 @@
 groups = ["default", "docs", "formatter", "linting", "test", "typesafety"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:411050a706445d379d242eae3ef789cb2d5f7c1da8fb18ec9e7eb262794d81ff"
+content_hash = "sha256:d99c01bc2fd0d63feb6bc0801a2498e1c96202731bc102135e050c4c88be9896"
 
 [[metadata.targets]]
 requires_python = "==3.11.*"
@@ -555,23 +555,23 @@ files = [
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
-requires_python = ">=3.9"
+version = "9.0.2"
+requires_python = ">=3.10"
 summary = "pytest: simple powerful testing with Python"
 groups = ["test"]
 marker = "python_version == \"3.11\""
 dependencies = [
     "colorama>=0.4; sys_platform == \"win32\"",
     "exceptiongroup>=1; python_version < \"3.11\"",
-    "iniconfig>=1",
-    "packaging>=20",
+    "iniconfig>=1.0.1",
+    "packaging>=22",
     "pluggy<2,>=1.5",
     "pygments>=2.7.2",
     "tomli>=1; python_version < \"3.11\"",
 ]
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b"},
+    {file = "pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11"},
 ]
 
 [[package]]
@@ -628,7 +628,7 @@ name = "python-dateutil"
 version = "2.9.0.post0"
 requires_python = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
 summary = "Extensions to the standard Python datetime module"
-groups = ["docs", "test"]
+groups = ["docs"]
 marker = "python_version == \"3.11\""
 dependencies = [
     "six>=1.5",
@@ -690,36 +690,11 @@ name = "six"
 version = "1.17.0"
 requires_python = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
 summary = "Python 2 and 3 compatibility utilities"
-groups = ["docs", "test"]
+groups = ["docs"]
 marker = "python_version == \"3.11\""
 files = [
     {file = "six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274"},
     {file = "six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81"},
-]
-
-[[package]]
-name = "time-machine"
-version = "2.19.0"
-requires_python = ">=3.9"
-summary = "Travel through time in your tests."
-groups = ["test"]
-marker = "python_version == \"3.11\""
-dependencies = [
-    "python-dateutil",
-]
-files = [
-    {file = "time_machine-2.19.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:5ee91664880434d98e41585c3446dac7180ec408c786347451ddfca110d19296"},
-    {file = "time_machine-2.19.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:ed3732b83a893d1c7b8cabde762968b4dc5680ee0d305b3ecca9bb516f4e3862"},
-    {file = "time_machine-2.19.0-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:6ba0303e9cc9f7f947e344f501e26bedfb68fab521e3c2729d370f4f332d2d55"},
-    {file = "time_machine-2.19.0-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2851825b524a988ee459c37c1c26bdfaa7eff78194efb2b562ea497a6f375b0a"},
-    {file = "time_machine-2.19.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:68d32b09ecfd7fef59255c091e8e7c24dd117f882c4880b5c7ab8c5c32a98f89"},
-    {file = "time_machine-2.19.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:60c46ab527bf2fa144b530f639cc9e12803524c9e1f111dc8c8f493bb6586eeb"},
-    {file = "time_machine-2.19.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:56f26ab9f0201c453d18fe76bb7d1cf05fe58c1b9d9cb0c7d243d05132e01292"},
-    {file = "time_machine-2.19.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:6c806cf3c1185baa1d807b7f51bed0db7a6506832c961d5d1b4c94c775749bc0"},
-    {file = "time_machine-2.19.0-cp311-cp311-win32.whl", hash = "sha256:b30039dfd89855c12138095bee39c540b4633cbc3684580d684ef67a99a91587"},
-    {file = "time_machine-2.19.0-cp311-cp311-win_amd64.whl", hash = "sha256:13ed8b34430f1de79905877f5600adffa626793ab4546a70a99fb72c6a3350d8"},
-    {file = "time_machine-2.19.0-cp311-cp311-win_arm64.whl", hash = "sha256:cc29a50a0257d8750b08056b66d7225daab47606832dea1a69e8b017323bf511"},
-    {file = "time_machine-2.19.0.tar.gz", hash = "sha256:7c5065a8b3f2bbb449422c66ef71d114d3f909c276a6469642ecfffb6a0fcd29"},
 ]
 
 [[package]]

--- a/py3.12.lock
+++ b/py3.12.lock
@@ -5,7 +5,7 @@
 groups = ["default", "docs", "formatter", "linting", "test", "typesafety"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:411050a706445d379d242eae3ef789cb2d5f7c1da8fb18ec9e7eb262794d81ff"
+content_hash = "sha256:d99c01bc2fd0d63feb6bc0801a2498e1c96202731bc102135e050c4c88be9896"
 
 [[metadata.targets]]
 requires_python = "==3.12.*"
@@ -555,23 +555,23 @@ files = [
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
-requires_python = ">=3.9"
+version = "9.0.2"
+requires_python = ">=3.10"
 summary = "pytest: simple powerful testing with Python"
 groups = ["test"]
 marker = "python_version == \"3.12\""
 dependencies = [
     "colorama>=0.4; sys_platform == \"win32\"",
     "exceptiongroup>=1; python_version < \"3.11\"",
-    "iniconfig>=1",
-    "packaging>=20",
+    "iniconfig>=1.0.1",
+    "packaging>=22",
     "pluggy<2,>=1.5",
     "pygments>=2.7.2",
     "tomli>=1; python_version < \"3.11\"",
 ]
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b"},
+    {file = "pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11"},
 ]
 
 [[package]]
@@ -628,7 +628,7 @@ name = "python-dateutil"
 version = "2.9.0.post0"
 requires_python = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
 summary = "Extensions to the standard Python datetime module"
-groups = ["docs", "test"]
+groups = ["docs"]
 marker = "python_version == \"3.12\""
 dependencies = [
     "six>=1.5",
@@ -691,36 +691,11 @@ name = "six"
 version = "1.17.0"
 requires_python = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
 summary = "Python 2 and 3 compatibility utilities"
-groups = ["docs", "test"]
+groups = ["docs"]
 marker = "python_version == \"3.12\""
 files = [
     {file = "six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274"},
     {file = "six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81"},
-]
-
-[[package]]
-name = "time-machine"
-version = "2.19.0"
-requires_python = ">=3.9"
-summary = "Travel through time in your tests."
-groups = ["test"]
-marker = "python_version == \"3.12\""
-dependencies = [
-    "python-dateutil",
-]
-files = [
-    {file = "time_machine-2.19.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:c85cf437dc3c07429456d8d6670ac90ecbd8241dcd0fbf03e8db2800576f91ff"},
-    {file = "time_machine-2.19.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d9238897e8ef54acdf59f5dff16f59ca0720e7c02d820c56b4397c11db5d3eb9"},
-    {file = "time_machine-2.19.0-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:e312c7d5d6bfffb96c6a7b39ff29e3046de100d7efaa3c01552654cfbd08f14c"},
-    {file = "time_machine-2.19.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:714c40b2c90d1c57cc403382d5a9cf16e504cb525bfe9650095317da3c3d62b5"},
-    {file = "time_machine-2.19.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2eaa1c675d500dc3ccae19e9fb1feff84458a68c132bbea47a80cc3dd2df7072"},
-    {file = "time_machine-2.19.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e77a414e9597988af53b2b2e67242c9d2f409769df0d264b6d06fda8ca3360d4"},
-    {file = "time_machine-2.19.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:cd93996970e11c382b04d4937c3cd0b0167adeef14725ece35aae88d8a01733c"},
-    {file = "time_machine-2.19.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:8e20a6d8d6e23174bd7e931e134d9610b136db460b249d07e84ecdad029ec352"},
-    {file = "time_machine-2.19.0-cp312-cp312-win32.whl", hash = "sha256:95afc9bc65228b27be80c2756799c20b8eb97c4ef382a9b762b6d7888bc84099"},
-    {file = "time_machine-2.19.0-cp312-cp312-win_amd64.whl", hash = "sha256:e84909af950e2448f4e2562ea5759c946248c99ab380d2b47d79b62bd76fa236"},
-    {file = "time_machine-2.19.0-cp312-cp312-win_arm64.whl", hash = "sha256:0390a1ea9fa7e9d772a39b7c61b34fdcca80eb9ffac339cc0441c6c714c81470"},
-    {file = "time_machine-2.19.0.tar.gz", hash = "sha256:7c5065a8b3f2bbb449422c66ef71d114d3f909c276a6469642ecfffb6a0fcd29"},
 ]
 
 [[package]]

--- a/py3.13.lock
+++ b/py3.13.lock
@@ -5,7 +5,7 @@
 groups = ["default", "docs", "formatter", "linting", "test", "typesafety"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:411050a706445d379d242eae3ef789cb2d5f7c1da8fb18ec9e7eb262794d81ff"
+content_hash = "sha256:d99c01bc2fd0d63feb6bc0801a2498e1c96202731bc102135e050c4c88be9896"
 
 [[metadata.targets]]
 requires_python = "==3.13.*"
@@ -592,23 +592,23 @@ files = [
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
-requires_python = ">=3.9"
+version = "9.0.2"
+requires_python = ">=3.10"
 summary = "pytest: simple powerful testing with Python"
 groups = ["test"]
 marker = "python_version == \"3.13\""
 dependencies = [
     "colorama>=0.4; sys_platform == \"win32\"",
     "exceptiongroup>=1; python_version < \"3.11\"",
-    "iniconfig>=1",
-    "packaging>=20",
+    "iniconfig>=1.0.1",
+    "packaging>=22",
     "pluggy<2,>=1.5",
     "pygments>=2.7.2",
     "tomli>=1; python_version < \"3.11\"",
 ]
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b"},
+    {file = "pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11"},
 ]
 
 [[package]]
@@ -665,7 +665,7 @@ name = "python-dateutil"
 version = "2.9.0.post0"
 requires_python = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
 summary = "Extensions to the standard Python datetime module"
-groups = ["docs", "test"]
+groups = ["docs"]
 marker = "python_version == \"3.13\""
 dependencies = [
     "six>=1.5",
@@ -728,47 +728,11 @@ name = "six"
 version = "1.17.0"
 requires_python = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
 summary = "Python 2 and 3 compatibility utilities"
-groups = ["docs", "test"]
+groups = ["docs"]
 marker = "python_version == \"3.13\""
 files = [
     {file = "six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274"},
     {file = "six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81"},
-]
-
-[[package]]
-name = "time-machine"
-version = "2.19.0"
-requires_python = ">=3.9"
-summary = "Travel through time in your tests."
-groups = ["test"]
-marker = "python_version == \"3.13\""
-dependencies = [
-    "python-dateutil",
-]
-files = [
-    {file = "time_machine-2.19.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:5e172866753e6041d3b29f3037dc47c20525176a494a71bbd0998dfdc4f11f2f"},
-    {file = "time_machine-2.19.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:f70f68379bd6f542ae6775cce9a4fa3dcc20bf7959c42eaef871c14469e18097"},
-    {file = "time_machine-2.19.0-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:e69e0b0f694728a00e72891ef8dd00c7542952cb1c87237db594b6b27d504a96"},
-    {file = "time_machine-2.19.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:3ae0a8b869574301ec5637e32c270c7384cca5cd6e230f07af9d29271a7fa293"},
-    {file = "time_machine-2.19.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:554e4317de90e2f7605ff80d153c8bb56b38c0d0c0279feb17e799521e987b8c"},
-    {file = "time_machine-2.19.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:6567a5ec5538ed550539ac29be11b3cb36af1f9894e2a72940cba0292cc7c3c9"},
-    {file = "time_machine-2.19.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:82e9ffe8dfff07b0d810a2ad015a82cd78c6a237f6c7cf185fa7f747a3256f8a"},
-    {file = "time_machine-2.19.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:7e1c4e578cdd69b3531d8dd3fbcb92a0cd879dadb912ee37af99c3a9e3c0d285"},
-    {file = "time_machine-2.19.0-cp313-cp313-win32.whl", hash = "sha256:72dbd4cbc3d96dec9dd281ddfbb513982102776b63e4e039f83afb244802a9e5"},
-    {file = "time_machine-2.19.0-cp313-cp313-win_amd64.whl", hash = "sha256:e17e3e089ac95f9a145ce07ff615e3c85674f7de36f2d92aaf588493a23ffb4b"},
-    {file = "time_machine-2.19.0-cp313-cp313-win_arm64.whl", hash = "sha256:149072aff8e3690e14f4916103d898ea0d5d9c95531b6aa0995251c299533f7b"},
-    {file = "time_machine-2.19.0-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:f3589fee1ed0ab6ee424a55b0ea1ec694c4ba64cc26895bcd7d99f3d1bc6a28a"},
-    {file = "time_machine-2.19.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:7887e85275c4975fe54df03dcdd5f38bd36be973adc68a8c77e17441c3b443d6"},
-    {file = "time_machine-2.19.0-cp313-cp313t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:ce0be294c209928563fcce1c587963e60ec803436cf1e181acd5bc1e425d554b"},
-    {file = "time_machine-2.19.0-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:a62fd1ab380012c86f4c042010418ed45eb31604f4bf4453e17c9fa60bc56a29"},
-    {file = "time_machine-2.19.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b25ec853a4530a5800731257f93206b12cbdee85ede964ebf8011b66086a7914"},
-    {file = "time_machine-2.19.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:a430e4d0e0556f021a9c78e9b9f68e5e8910bdace4aa34ed4d1a73e239ed9384"},
-    {file = "time_machine-2.19.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:2415b7495ec4364c8067071e964fbadfe746dd4cdb43983f2f0bd6ebed13315c"},
-    {file = "time_machine-2.19.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:dbfc6b90c10f288594e1bf89a728a98cc0030791fd73541bbdc6b090aff83143"},
-    {file = "time_machine-2.19.0-cp313-cp313t-win32.whl", hash = "sha256:16f5d81f650c0a4d117ab08036dc30b5f8b262e11a4a0becc458e7f1c011b228"},
-    {file = "time_machine-2.19.0-cp313-cp313t-win_amd64.whl", hash = "sha256:645699616ec14e147094f601e6ab9553ff6cea37fad9c42720a6d7ed04bcd5dc"},
-    {file = "time_machine-2.19.0-cp313-cp313t-win_arm64.whl", hash = "sha256:b32daa965d13237536ea3afaa5ad61ade2b2d9314bc3a20196a0d2e1d7b57c6a"},
-    {file = "time_machine-2.19.0.tar.gz", hash = "sha256:7c5065a8b3f2bbb449422c66ef71d114d3f909c276a6469642ecfffb6a0fcd29"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,10 +37,9 @@ path = "src/calendar_queue/__init__.py"
 
 [tool.pdm.dev-dependencies]
 test = [
-    "pytest~=8.1",
-    "time-machine~=2.16",
-    "pytest-asyncio>=1.0",
-    "pytest-cov>=6.2",
+    "pytest~=9.0",
+    "pytest-asyncio>=1.3",
+    "pytest-cov>=7.0",
     "pytest-timeout>=2.4",
 ]
 docs = [

--- a/tests/test_calendar.py
+++ b/tests/test_calendar.py
@@ -1,4 +1,3 @@
-import math
 from datetime import datetime, timedelta
 from time import time
 
@@ -30,18 +29,14 @@ async def test_schedule():
     c.schedule("foo", ts)
 
     # check that the next in line is the correct one and that the time remaining is approximately the same (can't check exact)
-    assert c.next_scheduled() == "foo" and math.isclose(
-        c.time_remaining(), ts.timestamp() - time(), abs_tol=ABS_TOLERANCE
-    )
+    assert c.next_scheduled() == "foo" and c.time_remaining() == pytest.approx(ts.timestamp() - time(), abs=ABS_TOLERANCE)
 
     c.clear()
 
     c.schedule("bar", ts.timestamp())
 
     # check that the next in line is the correct one and that the time remaining is approximately the same (can't check exact)
-    assert c.next_scheduled() == "bar" and math.isclose(
-        c.time_remaining(), ts.timestamp() - time(), abs_tol=ABS_TOLERANCE
-    )
+    assert c.next_scheduled() == "bar" and c.time_remaining() == pytest.approx(ts.timestamp() - time(), abs=ABS_TOLERANCE)
 
 
 @pytest.mark.asyncio
@@ -61,7 +56,7 @@ async def test_events_generator():
     count = 0
     async for ts, event in c.events():
         # ensure events are yielded at the right time
-        assert time() >= ts or math.isclose(time(), ts)
+        assert time() >= ts or time() == pytest.approx(ts)
         assert event == count
         count += 1
 
@@ -98,7 +93,7 @@ async def test_run_async_executor():
     async def async_executor(ts, item, calendar):
         nonlocal count
 
-        assert time() >= ts or math.isclose(time(), ts)
+        assert time() >= ts or time() == pytest.approx(ts)
         assert item == count
         assert calendar == c
 
@@ -137,7 +132,7 @@ async def test_run_executor():
         nonlocal count
         nonlocal test_done
 
-        assert time() >= ts or math.isclose(time(), ts)
+        assert time() >= ts or time() == pytest.approx(ts)
         assert item == count
         assert calendar == c
 
@@ -190,7 +185,7 @@ async def test_cancel_events():
     )
 
     async for ts, event in c.events():
-        assert time() >= ts or math.isclose(time(), ts)
+        assert time() >= ts or time() == pytest.approx(ts)
         assert not event % 2
 
         if len(c.remaining_events()) == 0:

--- a/tests/test_calendar_queue.py
+++ b/tests/test_calendar_queue.py
@@ -1,11 +1,10 @@
 import asyncio
-import math
 import sys
-from datetime import datetime, timedelta
+from datetime import timedelta
 from time import time
+from unittest.mock import patch
 
 import pytest
-import time_machine
 
 from calendar_queue import CalendarQueue
 from tests import ABS_TOLERANCE
@@ -18,7 +17,7 @@ def test_init():
 
 @pytest.mark.asyncio
 @pytest.mark.skipif(
-    sys.version_info <= (3, 13),
+    sys.version_info < (3, 13),
     reason="Queue shutdown is supported only from python 3.13 on",
 )
 async def test_queue_shutdown():
@@ -26,11 +25,11 @@ async def test_queue_shutdown():
     is correctly raised when putting or getting after shutting down the queue
     """
 
-    from asyncio import QueueShutDown
+    from asyncio import QueueShutDown # type: ignore
 
     cq = CalendarQueue()
 
-    cq.shutdown()
+    cq.shutdown() # type: ignore
 
     with pytest.raises(QueueShutDown):
         await cq.get()
@@ -50,7 +49,7 @@ async def test_simple_put():
 
     base_ts = time()
 
-    base_loop_ts = cq._get_loop().time()
+    base_loop_ts = cq._get_loop().time() # type: ignore
 
     ts_1 = base_ts + 10
 
@@ -60,10 +59,10 @@ async def test_simple_put():
 
     assert cq.peek() == foo[-1]
 
+    assert cq._getter_timer is not None
+
     # check timer is correct (we can't match the exact timestamp)
-    assert math.isclose(
-        cq._getter_timer.when(), base_loop_ts + 10, abs_tol=ABS_TOLERANCE
-    )
+    assert cq._getter_timer.when() == pytest.approx(base_loop_ts + 10, abs=ABS_TOLERANCE)
 
     ts_2 = base_ts + 5
 
@@ -74,9 +73,7 @@ async def test_simple_put():
     assert cq.peek() == bar[-1]
 
     # check timer is correct (we can't match the exact timestamp)
-    assert math.isclose(
-        cq._getter_timer.when(), base_loop_ts + 5, abs_tol=ABS_TOLERANCE
-    )
+    assert cq._getter_timer.when() == pytest.approx(base_loop_ts + 5, abs=ABS_TOLERANCE)
 
 
 @pytest.mark.asyncio
@@ -93,7 +90,7 @@ async def test_get():
 
     # check timer is correct (we can't match the exact timestamp)
     assert (await cq.get()) == foo and (
-        time() >= foo[0] or math.isclose(time(), foo[0])
+        time() >= foo[0] or time() == pytest.approx(foo[0])
     )
 
 
@@ -117,12 +114,14 @@ async def test_delete_items():
 @pytest.mark.asyncio
 async def test_far_schedule():
     """Test putting an event scheduled far in time.
-    We use time-machine to simulate the time traveling
+    We use LoopTimeTravel to simulate the time traveling
     and verify that the elements are returned at the correct
     timestamp.
     """
 
     cq = CalendarQueue()
+
+    cq_loop = cq._get_loop() # type: ignore
 
     delta = timedelta(days=30)
 
@@ -132,68 +131,9 @@ async def test_far_schedule():
         await asyncio.wait_for(cq.get(), 2)
         pytest.fail("Item was returned immediately. It makes no sense.")
 
-    with time_machine.travel((datetime.now() + delta + timedelta(seconds=10))):
+    with patch.object(cq_loop, "time", return_value=cq_loop.time() + delta.total_seconds() + 10):
         item = await asyncio.wait_for(cq.get(), 5)
         assert item[-1] == "foo"
-
-
-@pytest.mark.asyncio
-async def test_far_schedule_alt():
-    """Another far schedule test still using time-machine.
-    This time two tasks are defined, both depends on time-machine's
-    timestamp
-    - task 1 puts an item, verifies that is's not immediately returned,
-        sets an asyncio.Event and awaits for the event to be returned
-    - task 2 awaits for the Event to be set by task 1 and then shifts
-        the time so that the test doesn't have to wait for 1 month to
-        be done.
-    """
-
-    cq = CalendarQueue()
-
-    delta = timedelta(days=30)
-
-    time_shift_event = asyncio.Event()
-    test_done_event = asyncio.Event()
-
-    with time_machine.travel(0) as traveler:
-
-        async def put_item():
-            cq.put_nowait((time() + delta.total_seconds(), "foo"))
-
-            with pytest.raises((TimeoutError, asyncio.TimeoutError)):
-                await asyncio.wait_for(cq.get(), 1)
-                pytest.fail("Item was returned immediately. It makes no sense.")
-
-            time_shift_event.set()
-
-            item = await cq.get()
-
-            assert item[-1] == "foo"
-
-            test_done_event.set()
-
-        async def shift_time():
-
-            await time_shift_event.wait()
-
-            traveler.shift(delta.total_seconds() + 10)
-
-            await asyncio.wait_for(test_done_event.wait(), 2)
-
-        tasks = [
-            asyncio.create_task(put_item(), name="put"),
-            asyncio.create_task(shift_time(), name="shift"),
-        ]
-
-        await asyncio.wait(tasks, return_when=asyncio.ALL_COMPLETED)
-
-        done, pending = await asyncio.wait(tasks, return_when=asyncio.ALL_COMPLETED)
-
-        for d in done:
-            assert d.exception() is None
-
-        assert not pending
 
 
 @pytest.mark.asyncio
@@ -207,28 +147,24 @@ async def test_put():
     cq_nosize = CalendarQueue()
 
     base_ts = time()
-    base_loop_ts = cq_nosize._get_loop().time()
+    base_loop_ts = cq_nosize._get_loop().time() # type: ignore
 
     await cq_nosize.put((base_ts + 180, "foo"))
 
+    assert cq_nosize._getter_timer is not None
+
     # check timer is correct (we can't match the exact timestamp)
-    assert math.isclose(
-        cq_nosize._getter_timer.when(), base_loop_ts + 180, abs_tol=ABS_TOLERANCE
-    )
+    assert cq_nosize._getter_timer.when() == pytest.approx(base_loop_ts + 180, abs=ABS_TOLERANCE)
 
     await cq_nosize.put((base_ts + 300, "bar"))
 
     # check timer is correct (we can't match the exact timestamp)
-    assert math.isclose(
-        cq_nosize._getter_timer.when(), base_loop_ts + 180, abs_tol=ABS_TOLERANCE
-    )
+    assert cq_nosize._getter_timer.when() == pytest.approx(base_loop_ts + 180, abs=ABS_TOLERANCE)
 
     await cq_nosize.put((base_ts + 90, "baz"))
 
     # check timer is correct (we can't match the exact timestamp)
-    assert math.isclose(
-        cq_nosize._getter_timer.when(), base_loop_ts + 90, abs_tol=ABS_TOLERANCE
-    )
+    assert cq_nosize._getter_timer.when() == pytest.approx(base_loop_ts + 90, abs=ABS_TOLERANCE)
 
     assert cq_nosize.qsize() == 3
 
@@ -269,13 +205,13 @@ async def test_put_limited_q():
         ts, item = await asyncio.wait_for(cq.get(), first_ts - time() + 0.5)
         assert (
             ts == first_ts
-            and (time() >= ts or math.isclose(time(), ts))
+            and (time() >= ts or time() == pytest.approx(ts))
             and item == "foo"
         )
         ts, item = await asyncio.wait_for(cq.get(), second_ts - time() + 0.5)
         assert (
             ts == second_ts
-            and (time() >= ts or math.isclose(time(), ts))
+            and (time() >= ts or time() == pytest.approx(ts))
             and item == "bar"
         )
 
@@ -306,14 +242,15 @@ async def test_next_in():
     delta_2 = 2
 
     scheduled_ts = time() + delta_1
-    base_loop_ts = cq._get_loop().time()
+    base_loop_ts = cq._get_loop().time() # type: ignore
 
     cq.put_nowait((scheduled_ts, "foo"))
 
-    assert cq.next_in() and int(cq.next_in()) == int(scheduled_ts - time())
-    assert math.isclose(
-        cq._getter_timer.when(), base_loop_ts + delta_1, abs_tol=ABS_TOLERANCE
-    )
+    assert cq.next_in() is not None and int(cq.next_in() or 0) == int(scheduled_ts - time())
+
+    assert cq._getter_timer is not None
+
+    assert cq._getter_timer.when() == pytest.approx(base_loop_ts + delta_1, abs=ABS_TOLERANCE)
 
     cq.put_nowait((time() + delta_2, "bar"))
 
@@ -355,24 +292,22 @@ async def test_delete():
     cq = CalendarQueue()
 
     base_ts = time()
-    base_loop_ts = cq._get_loop().time()
+    base_loop_ts = cq._get_loop().time() # type: ignore
 
     cq.put_nowait((base_ts + 120, "bar"))
     cq.put_nowait((base_ts + 60, "foo"))
     cq.put_nowait((base_ts + 180, "baz"))
 
-    assert math.isclose(
-        cq._getter_timer.when(), base_loop_ts + 60, abs_tol=ABS_TOLERANCE
-    )
+    assert cq._getter_timer is not None
+
+    assert cq._getter_timer.when() == pytest.approx(base_loop_ts + 60, abs=ABS_TOLERANCE)
 
     del_items = cq.delete_items(lambda x: x[1] == "foo")
 
     assert (
         len(del_items) == 1
         and del_items[0] == (base_ts + 60, "foo")
-        and math.isclose(
-            cq._getter_timer.when(), base_loop_ts + 120, abs_tol=ABS_TOLERANCE
-        )
+        and cq._getter_timer.when() == pytest.approx(base_loop_ts + 120, abs=ABS_TOLERANCE)
     )
 
     assert cq.qsize() == 2


### PR DESCRIPTION
Update test dependencies: `pytest`, `pytest-asyncio`, `pytest-cov`. Remove `time-machine` usage because they dropped support for mocking monotonic (which is needed for asyncio based tests). 