### PR TITLE
Feat/new calendar interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,39 @@
+# Changelog
+
+## [0.2.0] - 2026-01-01
+
+### Changed
+
+- **Breaking Change**: Removed the executor pattern from `Calendar` class. The `executor` attribute and the `run()` method are no longer available.
+- **Breaking Change**: `Calendar.events()` method returns the list of queued events. The async iterator is now implemented within the `Calendar` class (`__aiter__` and `__anext__`). The `Calendar` class can now be used directly in `async for` loops.
+- **Breaking Change**: The queue is no longer automatically cleared before starting to iterate over events. Previously, calling the async iterator would clear any pending events; now existing events are preserved.
+- Simplified the `Calendar` API by removing the experimental executor pattern in favor of always using async iteration
+
+### Updated
+
+- Updated all documentation examples to use the new async iterator interface
+- Updated tutorial examples to demonstrate the new `async for` usage pattern with `Calendar`
+- Updated test suite to reflect the new async iterator implementation
+- Added support for Python 3.14
+- Updated CI/CD workflows for Python 3.14 compatibility
+- Updated development dependencies
+
+### Migration Guide
+
+**Before (v0.1.0):**
+
+```python
+async for ts, event in calendar.events():
+    # handle event
+```
+
+**After (v0.2.0):**
+
+```python
+async for ts, event in calendar:
+    # handle event
+```
+
+## [0.1.0] - Previous Release
+
+Initial `calendar-queue` release.

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,6 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 85% # the required coverage value
+        threshold: 1% # the leniency in hitting the target

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,0 +1,1 @@
+../CHANGELOG.md

--- a/docs/tutorials/calendar.md
+++ b/docs/tutorials/calendar.md
@@ -29,10 +29,9 @@ calendar.schedule(item=event, when=ts)
 
 Scheduled events can be checked using the methods:
 
-1. `next_scheduled`: to get the next scheduled event, None if there are no scheduled events 
-1. `time_remaining`: to get the time (seconds) remaining to the next event, None if there are no scheduled events 
+1. `next_scheduled`: to get the next scheduled event, None if there are no scheduled events
+1. `time_remaining`: to get the time (seconds) remaining to the next event, None if there are no scheduled events
 1. `remaining_events`: to get all remaining scheduled events
-
 
 ### Cancelling an event
 
@@ -50,7 +49,7 @@ def event_selector(item: tuple[int, Any]):
 
     if ts <= deadline:
         return True
-    
+
     return False
 
 cancelled_events = calendar.cancel_event(event_selector)
@@ -74,38 +73,12 @@ calendar.clear()
 
 ## Running the calendar
 
-Now that we know how to schedule events, we need to consume the events as they happen. To do so we currently provide two approaches:
-
-1. an `events` method which returns a generator
-1. by setting an executor and then running the calendar
-
-### Using the generator
-
-The `events` method it's an asynchronous generator which yields a tuple of `timestamp` and `Event` as they are released from the internal calendar queue.
+Now that we know how to schedule events, we need to consume the events as they happen which can be done using the class as an asynchronous generator which yields a tuple of `timestamp` and `Event` as they are released from the internal calendar queue.
 
 ```python
 
-async for ts, event in calendar.events():
-    
+async for ts, event in calendar:
+
     # do stuff with the emitted events
-
-```
-
-## Using the executor
-
-Another approach is defining an executor function which will be executed every time an event is emitted by the internal calendar queue.
-The executor function can be a coroutine or a regular function, the calendar will execute it accordingly.
-
-```python
-
-def custom_executor(ts, event, calendar_instance):
-
-    # do stuff with emitted event
-    ...
-
-calendar.set_executor(custom_executor)
-
-# the calendar can be stopped by another task (or by the executor) by calling calendar.stop()
-await calendar.run()
 
 ```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -14,8 +14,6 @@ nav:
 plugins:
   - search
   - mkdocstrings:
-      handlers:
-        python:
-          options:
-            members_order: source
-            returns_named_value: false
+      options:
+        members_order: source
+        returns_named_value: false

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,18 +3,19 @@ theme:
   name: readthedocs
 nav:
   - Introduction: index.md
-  - Tutorials: 
-    - CalendarQueue: tutorials/calendar-queue.md 
-    - Calendar: tutorials/calendar.md 
-  - API Reference: 
-    - CalendarQueue: api-reference/calendar-queue.md 
-    - Calendar: api-reference/calendar.md 
+  - Tutorials:
+      - CalendarQueue: tutorials/calendar-queue.md
+      - Calendar: tutorials/calendar.md
+  - API Reference:
+      - CalendarQueue: api-reference/calendar-queue.md
+      - Calendar: api-reference/calendar.md
+  - Changelog: changelog.md
 
 plugins:
-- search
-- mkdocstrings:
-    handlers:
-      python:
-        options:
-          members_order: source
-          returns_named_value: false
+  - search
+  - mkdocstrings:
+      handlers:
+        python:
+          options:
+            members_order: source
+            returns_named_value: false

--- a/src/calendar_queue/__init__.py
+++ b/src/calendar_queue/__init__.py
@@ -2,6 +2,5 @@
 
 from .calendar_queue import CalendarEvent, CalendarQueue
 from .calendar import Calendar
-from .exceptions import CalendarMissingExecutor
 
 __version__ = "0.1.0"

--- a/src/calendar_queue/calendar.py
+++ b/src/calendar_queue/calendar.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import asyncio
 from copy import deepcopy
 from datetime import datetime
-from typing import Any, AsyncGenerator, Awaitable, Callable, Generic, Optional
+from typing import Any, Awaitable, Callable, Generic, Optional
 
 from calendar_queue.calendar_queue import CalendarEvent, CalendarQueue
 
@@ -19,14 +19,7 @@ class Calendar(Generic[CalendarEvent]):
     """An experimental Calendar class to facilitate the use of CalendarQueue
     for scheduling events.
 
-    It provides a an `events` method which returns an async generator that
-    can be used to await for events.
-
-    Additionally it provides a `run` method which can be used only after
-    setting an executor function, the executor can be an a sync or an async
-    function and will be called every time an event is scheduled to happen,
-    receiving the scheduled timestamp, the event and the Calendar object.
-
+    It can be used as async generator that can be used to await for events.
 
     Note:
         `CalendarEvent` is a type which represents the objects that
@@ -94,67 +87,68 @@ class Calendar(Generic[CalendarEvent]):
 
         return self._calendar_queue.delete_items(selector)
 
-    def remaining_events(self) -> list[tuple[float, CalendarEvent]]:
-        """Return the remaining scheduled events
-
-        Returns:
-            (int): The number of scheduled events
-        """
-
-        # pylint: disable=protected-access
+    def events(self) -> list[tuple[float, CalendarEvent]]:
+        """Get all scheduled events as a list of tuples."""
         return deepcopy(self._calendar_queue._queue)
 
-    async def events(self) -> AsyncGenerator[tuple[float, CalendarEvent], None]:
-        """This method returns an async generator which can be used for
-        awaiting events.
+    def __aiter__(self) -> Calendar[CalendarEvent]:
+        """Make the Calendar instance an async iterable.
 
-        Yields:
+        Returns:
+            Calendar: The Calendar instance itself
+        """
+        return self
+
+    async def __anext__(self) -> tuple[float, CalendarEvent]:
+        """Async iterator method to get the next scheduled event.
+
+        Returns:
             (Tuple(float, CalendarEvent)): A tuple of a timestamp (float)
                 and the scheduled event (CalendarEvent)
+
+        Raises:
+            StopAsyncIteration: When iteration is stopped via the stop() method
         """
-        self._stop_event.clear()
 
-        while True:
+        done, pending = await asyncio.wait(
+            [
+                asyncio.create_task(
+                    self._calendar_queue.get(), name="__calendar_event"
+                ),
+                asyncio.create_task(
+                    self._stop_event.wait(), name="__calendar_stop"
+                ),
+            ],
+            return_when=asyncio.FIRST_COMPLETED,
+        )
 
-            done, pending = await asyncio.wait(
-                [
-                    asyncio.create_task(
-                        self._calendar_queue.get(), name="__calendar_event"
-                    ),
-                    asyncio.create_task(
-                        self._stop_event.wait(), name="__calendar_stop"
-                    ),
-                ],
-                return_when=asyncio.FIRST_COMPLETED,
-            )
+        event: Optional[tuple[float, CalendarEvent]] = None
+        stop = False
 
-            event: Optional[tuple[float, CalendarEvent]] = None
-            stop = False
+        for d in done:
+            if e := d.exception():
+                raise e
 
-            for d in done:
-                if e := d.exception():
-                    raise e
+            if "__calendar_event" == d.get_name():
+                event = d.result()  # type: ignore
+            else:
+                stop = True
 
-                if "__calendar_event" == d.get_name():
-                    event = d.result()  # type: ignore
-                else:
-                    stop = True
+        for p in pending:
+            p.cancel()
 
-            for p in pending:
-                p.cancel()
+        # If the stop event was set AND we got a new event,
+        # we honour the stop and put back the gotten event
+        # into the queue
+        if stop:
+            if event is not None:
+                self._calendar_queue.put_nowait(event)
+            raise StopAsyncIteration
 
-            # If the stop event was set AND we got a new event,
-            # we honour the stop and put back the gotten event
-            # into the queue
-            if stop:
-                if event is not None:
-                    self._calendar_queue.put_nowait(event)
-                return
-            
-            if event is None:
-                raise RuntimeError("Unreachable state reached in Calendar.events")
+        if event is None:
+            raise RuntimeError("Unreachable state reached in Calendar.__anext__")
 
-            yield event
+        return event
 
     def stop(self) -> None:
         """Stop the execution of the calendar"""

--- a/src/calendar_queue/calendar.py
+++ b/src/calendar_queue/calendar.py
@@ -13,7 +13,6 @@ from datetime import datetime
 from typing import Any, AsyncGenerator, Awaitable, Callable, Generic, Optional
 
 from calendar_queue.calendar_queue import CalendarEvent, CalendarQueue
-from calendar_queue.exceptions import CalendarMissingExecutor
 
 
 class Calendar(Generic[CalendarEvent]):
@@ -78,23 +77,6 @@ class Calendar(Generic[CalendarEvent]):
             (Optional[float]): Time left in seconds.
         """
         return self._calendar_queue.next_in()
-
-    def set_executor(
-        self,
-        executor: (
-            Callable[[float | int, CalendarEvent, Calendar], Awaitable[Any]]
-            | Callable[[float | int, CalendarEvent, Calendar], Any]
-        ),
-    ) -> None:
-        """This method can be used to set an executor function which will
-        used in the `run` method every time an event is scheduled to happen.
-
-        Args:
-            executor (CalendarExecutor): A sync or async function which takes as
-                argument the scheduled timestamp of the event and the event.
-        """
-
-        self.executor = executor
 
     def cancel_event(
         self, selector: Callable[[tuple[float, CalendarEvent]], bool]
@@ -168,32 +150,11 @@ class Calendar(Generic[CalendarEvent]):
                 if event is not None:
                     self._calendar_queue.put_nowait(event)
                 return
+            
+            if event is None:
+                raise RuntimeError("Unreachable state reached in Calendar.events")
 
             yield event
-
-    async def run(self) -> None:
-        """This method requires an executor to be set with `set_executor`.
-        It will internally await for events and call the executor every
-        time an event is scheduled to happen
-
-
-        Raises:
-            CalendarMissingExecutor: If the executor is not set.
-        """
-
-        if self.executor is None:
-            raise CalendarMissingExecutor(
-                "Executor function must be set to run the calendar"
-            )
-
-        self._stop_event.clear()
-
-        async for ts, event in self.events():
-
-            if asyncio.iscoroutinefunction(self.executor):
-                await self.executor(ts, event, self)
-            else:
-                self.executor(ts, event, self)
 
     def stop(self) -> None:
         """Stop the execution of the calendar"""
@@ -208,10 +169,3 @@ class Calendar(Generic[CalendarEvent]):
         """
 
         return self._calendar_queue.delete_items(selector=lambda _: True)
-
-
-# Define Executor type hint, for users only
-CalendarExecutor = (
-    Callable[[float | int, CalendarEvent, Calendar], Awaitable[Any]]
-    | Callable[[float | int, CalendarEvent, Calendar], Any]
-)

--- a/src/calendar_queue/calendar.py
+++ b/src/calendar_queue/calendar.py
@@ -89,6 +89,7 @@ class Calendar(Generic[CalendarEvent]):
 
     def events(self) -> list[tuple[float, CalendarEvent]]:
         """Get all scheduled events as a list of tuples."""
+        # pylint: disable=protected-access
         return deepcopy(self._calendar_queue._queue)
 
     def __aiter__(self) -> Calendar[CalendarEvent]:

--- a/src/calendar_queue/exceptions.py
+++ b/src/calendar_queue/exceptions.py
@@ -1,7 +1,0 @@
-"""Define exceptions for calendar_queue"""
-
-
-class CalendarMissingExecutor(Exception):
-    """Exception raised when run is called but no executor
-    function is set in the Calendar instance.
-    """

--- a/tests/test_calendar.py
+++ b/tests/test_calendar.py
@@ -3,7 +3,7 @@ from time import time
 
 import pytest
 
-from calendar_queue import Calendar, CalendarMissingExecutor
+from calendar_queue import Calendar
 from tests import ABS_TOLERANCE
 
 MyItem = tuple[str, int]
@@ -78,87 +78,6 @@ async def test_events_generator():
 
 
 @pytest.mark.asyncio
-async def test_run_async_executor():
-    """Test the run method with an async executor"""
-
-    c: Calendar[int] = Calendar()
-
-    ts = datetime.now()
-
-    for i in range(5):
-        c.schedule(i, ts + timedelta(seconds=i * 1))
-
-    count = 0
-
-    async def async_executor(ts, item, calendar):
-        nonlocal count
-
-        assert time() >= ts or time() == pytest.approx(ts)
-        assert item == count
-        assert calendar == c
-
-        count += 1
-
-        if count == 5:
-            c.stop()
-
-    with pytest.raises(CalendarMissingExecutor):
-        await c.run()
-
-    c.set_executor(executor=async_executor)
-
-    await c.run()
-
-    assert count == 5
-
-
-@pytest.mark.asyncio
-async def test_run_executor():
-    """Test the run method with a regular synchronous function as executor"""
-
-    c: Calendar[int] = Calendar()
-
-    ts = datetime.now()
-
-    for i in range(5):
-        c.schedule(i, ts + timedelta(seconds=i))
-
-    c.schedule(5, ts + timedelta(seconds=4))
-
-    count = 0
-    test_done = False
-
-    def executor(ts, item, calendar):
-        nonlocal count
-        nonlocal test_done
-
-        assert time() >= ts or time() == pytest.approx(ts)
-        assert item == count
-        assert calendar == c
-
-        count += 1
-
-        if count >= 5:
-            if not test_done:
-                test_done = True
-
-            c.stop()
-
-    with pytest.raises(CalendarMissingExecutor):
-        await c.run()
-
-    c.set_executor(executor=executor)
-
-    await c.run()
-
-    assert count == 5
-
-    await c.run()
-
-    assert count == 6
-
-
-@pytest.mark.asyncio
 async def test_cancel_events():
     """Test that cancelling events remove them from the calendar
     and that the next in line is correctly scheduled"""
@@ -170,7 +89,7 @@ async def test_cancel_events():
     for i in range(5):
         c.schedule(i, ts + timedelta(seconds=i * 1))
 
-    len(c.remaining_events()) == 5
+    assert len(c.remaining_events()) == 5
 
     pick_events = lambda x: x[1] % 2
 

--- a/tests/test_calendar.py
+++ b/tests/test_calendar.py
@@ -54,7 +54,7 @@ async def test_events_generator():
         c.schedule(i, ts + timedelta(seconds=i * 1))
 
     count = 0
-    async for ts, event in c.events():
+    async for ts, event in c:
         # ensure events are yielded at the right time
         assert time() >= ts or time() == pytest.approx(ts)
         assert event == count
@@ -73,7 +73,7 @@ async def test_events_generator():
             count += 1
 
         if count == 5:
-            assert len(c.remaining_events()) == 0
+            assert len(c.events()) == 0
             c.stop()
 
 
@@ -89,7 +89,7 @@ async def test_cancel_events():
     for i in range(5):
         c.schedule(i, ts + timedelta(seconds=i * 1))
 
-    assert len(c.remaining_events()) == 5
+    assert len(c.events()) == 5
 
     pick_events = lambda x: x[1] % 2
 
@@ -97,15 +97,15 @@ async def test_cancel_events():
 
     assert len(cancelled_events) == 2 and all(pick_events(x) for x in cancelled_events)
 
-    remaining_events = c.remaining_events()
+    remaining_events = c.events()
 
     assert len(remaining_events) == 3 and all(
         not pick_events(x) for x in remaining_events
     )
 
-    async for ts, event in c.events():
+    async for ts, event in c:
         assert time() >= ts or time() == pytest.approx(ts)
         assert not event % 2
 
-        if len(c.remaining_events()) == 0:
+        if len(c.events()) == 0:
             c.stop()


### PR DESCRIPTION
Update the `Calendar` class interface:
1. Deprecate and remove _executor_ pattern.
2. Implement async event iterator into the Calendar class (`__aiter__` and `__anext__`).
3. `Calendar.events` now returns a copy of the queue's events (old `Calendar.remaining_events`)

The docs have been updated accordingly and a changelog was added to keep track of the project's changes.